### PR TITLE
Remove Background Script from Manifest

### DIFF
--- a/manifest-template.json
+++ b/manifest-template.json
@@ -7,10 +7,6 @@
     "permissions": ["activeTab", "declarativeContent", "identity", "storage"],
 
     "options_page": "options.html",
-    "background": {
-        "scripts": ["background.js"],
-        "persistent": false
-    },
     "browser_action": {
         "default_popup": "popup.html"
     },


### PR DESCRIPTION
Not actually generated by webpack. Could probably remove the actual js file too